### PR TITLE
feat: ajout utilisateur non-root pour l'api docker

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -19,5 +19,23 @@ COPY .env .
 #port de l'api
 EXPOSE 8000
 
+#variables pour la création de l'utilisateur non-root
+ARG GROUPNAME=restausimplon-group
+ARG USERNAME=restausimplon-app-user
+#ID du groupe
+ARG USER_GID=1000
+#ID de l'utilisateur
+ARG USER_UID=1000
+
+#Création du groupe et de l'utilisateur non-root
+RUN addgroup -g $USER_GID -S $GROUPNAME \
+    && adduser -u $USER_UID -S -G $GROUPNAME $USERNAME
+
+#Déclarer le nouvel utilisateur propriétaire du dossier app
+RUN chown -R $USERNAME:$GROUPNAME /app
+
+#Choisir le nouvel utilisateur comme utilisateur par défaut
+USER $USERNAME
+
 #Commande pour lancer l'application reload
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
pou tester qu'il s'agit d'un utilisateur docker qutra que root, après avoir lancé le docker compose
`docker exec -it compose_api_fastapi_container sh`
puis dans le docker
`whoami`
le nom de l'utilisateur devra être un autre nom que root